### PR TITLE
Modify Faust tests to not do slow conversion from numpy to strings

### DIFF
--- a/tests/faust_dsp/polyphonic_wavetable.dsp
+++ b/tests/faust_dsp/polyphonic_wavetable.dsp
@@ -4,25 +4,42 @@ declare options "[nvoices:8]"; // FaustProcessor has a property which will overr
 import("stdfaust.lib");
 
 // This example demonstrates using lagrange interpolation to improve
-// the sampling of a short waveform.
-// Specifically, we simulate only having 4 samples of a sine wave,
+// the sampling of a short wavetable.
+// Specifically, from Python we pass myCycle, 4 samples of a sine wave,
 // so the values are {0, 1, 0, -1}.
 // However, with Lagrange interpolation, we can turn these into a smooth sine wave!
 
-// The following variables are excluded from this file because they come
+// The following variable is excluded from this file because they come
 // from substitution with Python.
 // LAGRANGE_ORDER = 4; // lagrange order. [2-4] are good choices.
-// CYCLE_SEQ = waveform{0.0, 1.0, 0.0, -1.0} : !, _;
-// CYCLE_LENGTH = 4; // the length of CYCLE_SEQ
 
 freq = hslider("freq",200,50,1000,0.01); // note pitch
 gain = hslider("gain",0.1,0,1,0.01);     // note velocity
 gate = button("gate");                   // note on/off
 
+soundfile_full = soundfile("myCycle",1): _, !, _;
+
+S = 0, 0 : soundfile_full : _, !;
+soundfile_table = 0, _ : soundfile_full : !, _;
+
+declare lagrangeCoeffs author "Dario Sanfilippo";
+declare lagrangeCoeffs copyright "Copyright (C) 2021 Dario Sanfilippo
+    <sanfilippo.dario@gmail.com>";
+declare lagrangeCoeffs license "MIT license";
+// NOTE: this is a modification of the original it.frdtable so that
+// it works with a soundfile
+// https://github.com/grame-cncm/faustlibraries/blob/master/interpolators.lib
+frdtable(N, S, init, idx) =
+    it.lagrangeN(N, f_idx, par(i, N + 1, table(i_idx - int(N / 2) + i)))
+    with {
+        table(j) = int(ma.modulo(j, S)) : init;
+        f_idx = ma.frac(idx) + int(N / 2);
+        i_idx = int(idx);
+    };
+
 envVol = en.adsr(.002, 0.1, 0.9, .1, gate);
 
-ridx = os.hs_phasor(CYCLE_LENGTH, freq, envVol == 0.); // or (abs(envVol) < 1e-4)
+ridx = os.hs_phasor(S, freq, envVol == 0.); // or (abs(envVol) < 1e-4)
 
-process = it.frdtable(LAGRANGE_ORDER, CYCLE_LENGTH, CYCLE_SEQ, ridx)*gain*envVol*0.5 <: _, _;
-// polyphonic DSP code must declare a stereo effect
+process = frdtable(LAGRANGE_ORDER, S, soundfile_table, ridx)*gain*envVol*0.5 <: _, _;
 effect = _, _;

--- a/tests/test_faust_soundfile.py
+++ b/tests/test_faust_soundfile.py
@@ -11,6 +11,9 @@ def _test_faust_soundfile(sample_seq, output_path, sound_choice=0):
 
 	dsp_path = abspath("faust_dsp/soundfile.dsp")
 
+	if sample_seq.ndim == 1:
+		sample_seq = sample_seq.reshape(1, -1)
+
 	reversed_audio = np.flip(sample_seq[:,:int(44100*.5)], axis=-1)
 
 	# set_soundfiles


### PR DESCRIPTION
Modify Faust tests to not do slow conversion from numpy arrays to strings. Now it just uses the soundfile primitive passed via Python.